### PR TITLE
HWP 메타데이터 존재하지 않는 경우 NPE로 인한 작업 실패 해결

### DIFF
--- a/src/main/java/kr/dogfoot/hwp2hwpx/ForContentHPFFile.java
+++ b/src/main/java/kr/dogfoot/hwp2hwpx/ForContentHPFFile.java
@@ -43,6 +43,10 @@ public class ForContentHPFFile extends Converter {
     private void metadata() {
         SummaryInformation summaryInformation = parameter.hwp().summaryInformation();
 
+        if (summaryInformation == null) {
+            return;
+        }
+
         contentHPFFile.createMetaData();
 
         MetaData metaData  = contentHPFFile.metaData();


### PR DESCRIPTION
metadata 내에 summaryInformation가 null일 경우 아래 getAutor() 등 부분에서 NPE 발생하여 null체크 추가


[github.com/neolord0/hwplib](https://github.com/neolord0/hwplib/blob/main/sample_hwp/basic/%ED%91%9C.hwp)에 테스트 파일로 존재하는 데이터를 기준으로 테스트 중 NPE가 발생하여 null체크 추가하였습니다. 

확인 하시고 반영 부탁드립니다.