### PR TITLE
Fix NullPointerException when hwpShadowInfo is null

### DIFF
--- a/src/main/java/kr/dogfoot/hwp2hwpx/section/object/comm/ForDrawingObject.java
+++ b/src/main/java/kr/dogfoot/hwp2hwpx/section/object/comm/ForDrawingObject.java
@@ -46,6 +46,9 @@ public class ForDrawingObject {
 
 
     public static void shadow(DrawingShadow shadow, ShadowInfo hwpShadowInfo) {
+        if (hwpShadowInfo == null) {
+            return;
+        }
         shadow
                 .typeAnd(drawingShadowType(hwpShadowInfo.getType()))
                 .colorAnd(ValueConvertor.color(hwpShadowInfo.getColor()))


### PR DESCRIPTION
## Summary
Fixes a NullPointerException when `hwpShadowInfo` is null.

## Details
In some HWP documents, drawing objects do not contain `ShadowInfo`.
Calling `getType()` on a null `hwpShadowInfo` caused a runtime exception.

This change adds a null check to safely handle such cases
without changing existing behavior.

## Stack Trace
```
java.lang.NullPointerException: Cannot invoke "kr.dogfoot.hwplib.object.bodytext.control.gso.shapecomponent.shadowinfo.ShadowInfo.getType()" because "hwpShadowInfo" is null
        at kr.dogfoot.hwp2hwpx.section.object.comm.ForDrawingObject.shadow(ForDrawingObject.java:50)
```